### PR TITLE
Fix for IOError on py 2.7

### DIFF
--- a/discoIPC/ipc.py
+++ b/discoIPC/ipc.py
@@ -1,6 +1,7 @@
 """The DiscordIPC class."""
 
 import os
+from io import open
 import platform
 import re
 import json


### PR DESCRIPTION
This should fix the "IOError: [Errno 0] Error" exception with python 2.7, which happens when you try to update the presence.

Note that this was only tested on Windows with python 2, but although it's not tested with python 3, the function is simply an alias on that version, so it should technically still work.
Although the docs say to use unicode strings, I found that it still works without them, so I guess that isn't necessary after all?

[Related SO answer](https://stackoverflow.com/a/11176772)